### PR TITLE
fix type of FlutterErrorDetails.context

### DIFF
--- a/lib/src/nested_scroll_view_refresh_indicator.dart
+++ b/lib/src/nested_scroll_view_refresh_indicator.dart
@@ -360,7 +360,7 @@ class NestedScrollViewRefreshIndicatorState
             FlutterError.reportError(FlutterErrorDetails(
               exception: FlutterError('The onRefresh callback returned null.\n'
                   'The RefreshIndicator onRefresh callback must return a Future.'),
-              context: 'when calling onRefresh',
+              context: ErrorDescription('when calling onRefresh'),
               library: 'material library',
             ));
           return true;


### PR DESCRIPTION
stable of Flutter went up to v1.7.8, and FlutterErrorDetails.context is changed to DiagnosticsNode from String.

In this case, ErrorDescription is appropriate.